### PR TITLE
escaped the % characters in crontab to fix processing

### DIFF
--- a/crontab
+++ b/crontab
@@ -1,3 +1,3 @@
 PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 
-0 2 * * * tarsnap --keyfile /var/run/secrets/tarsnap --cachedir /cache -c -f $(date +%Y-%m-%d) /backup > /proc/$(cat /run/crond.pid)/fd/1 2> /proc/$(cat /run/crond.pid)/fd/2
+0 2 * * * tarsnap --keyfile /var/run/secrets/tarsnap --cachedir /cache -c -f $(date +\%Y-\%m-\%d) /backup > /proc/$(cat /run/crond.pid)/fd/1 2> /proc/$(cat /run/crond.pid)/fd/2


### PR DESCRIPTION
turns out, % has a special meaning in the context of crontab and this breaks the cron job execution