### PR TITLE
fixes for WSL2 path problems: use a docker volume instead of a bind m…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,5 +54,14 @@ ADD crontab /var/run/crontab
 
 RUN mkdir -p /var/run/secrets
 RUN mkdir -p /cache
+RUN mkdir -p /data
+
+# https://mail.tarsnap.com/tarsnap-users/msg00037.html
+ENV LC_ALL=C
+ENV LANG=C
+ENV LANGUAGE=C
+
+RUN dpkg-reconfigure locales
+
 
 CMD ["bash", "-c", "/entrypoint.sh"]

--- a/crontab
+++ b/crontab
@@ -1,3 +1,3 @@
 PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 
-0 2 * * * tarsnap --keyfile /var/run/secrets/tarsnap --cachedir /cache -c -f $(date +\%Y-\%m-\%d) /backup > /proc/$(cat /run/crond.pid)/fd/1 2> /proc/$(cat /run/crond.pid)/fd/2
+0 2 * * * tarsnap --keyfile /var/run/secrets/tarsnap --cachedir /data/cache -c -f $(date +\%Y-\%m-\%d) -C /data/backup/filingcabinet --exclude .git  . > /proc/$(cat /run/crond.pid)/fd/1 2> /proc/$(cat /run/crond.pid)/fd/2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,30 @@
 version: '3.7'
 services:
   tarsnap:
-    init: true
-    restart: always
+    #init: true
+    #restart: always
     logging:
       driver: "json-file"
       options:
         max-file: "5"
         max-size: "10m"
-    image: johnthenerd/tarsnap
-    healthcheck:
-      test: ps aux | grep cron | grep -v grep
-      interval: 1m30s
-      timeout: 10s
-      retries: 3
+    image: tarsnap
+    #healthcheck:
+      #test: ps aux | grep cron | grep -v grep
+      #interval: 1m30s
+      #timeout: 10s
+      #retries: 3
     environment:
-      TZ: America/St_Johns
+      TZ: America/New_York
     volumes:
-      - /cache:/cache
-      - /backup:/backup:ro
+      - tarsnap-data:/data
+      #- /cache:/home/znoop333/tarsnap-cache
+      #- /backup:/home/znoop333/filingcabinet:ro
     secrets:
       - tarsnap
 secrets:
   tarsnap:
+    file: tarsnap.key
+volumes:
+  tarsnap-data:
     external: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ fi
 if [ -z "$(ls -A /cache)" ]; then
   # make sure we have read permissions before running fsck
   if [[ -z "$(echo $key_permissions | grep reading)" ]] ; then
-     tarsnap --keyfile /var/run/secrets/tarsnap --cachedir /cache --fsck
+     tarsnap --keyfile /var/run/secrets/tarsnap --cachedir /data/cache --fsck
   fi
 fi
 


### PR DESCRIPTION
…ount because WSL2 has some path problems with /mnt/c vs. /c and neither of those really seems to work right, so an external volume mounted at /data fixes the file permissions and path problems.

the caveat is that the files tarsnap accesses must be 'docker cp' into and out of the volume.

and yet, docker secrets work normally!

another bug: tarsnap prints many errors of the form   Can't translate pathname x to UTF-8 . I set LANG=C to try to fix it, and the files get copied, but it doesn't suppress the errors due to UTF characters